### PR TITLE
Add eval starts-with and ends-with assertions

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -130,6 +130,7 @@ tests:
   - name: "버그 감지"
     input: "Review: function add(a,b) { return a - b }"
     assert:
+      - starts-with: "The bug"
       - contains: "subtract"
       - min-length: 30
 ```
@@ -146,7 +147,7 @@ $ pulser eval
   2 passed · 0 failed · 0.6s
 ```
 
-지원 assertions: `contains`, `not-contains`, `min-length`, `max-length`, `matches` (정규식).
+지원 assertions: `contains`, `not-contains`, `starts-with`, `ends-with`, `min-length`, `max-length`, `matches` (정규식).
 
 ### 종료 코드 (eval)
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ tests:
   - name: "catches bugs"
     input: "Review: function add(a,b) { return a - b }"
     assert:
+      - starts-with: "The bug"
       - contains: "subtract"
       - min-length: 30
 ```
@@ -148,7 +149,7 @@ $ pulser eval
   2 passed · 0 failed · 0.6s
 ```
 
-Supported assertions: `contains`, `not-contains`, `min-length`, `max-length`, `matches` (regex).
+Supported assertions: `contains`, `not-contains`, `starts-with`, `ends-with`, `min-length`, `max-length`, `matches` (regex).
 
 ### Exit Codes (eval)
 

--- a/docs/superpowers/specs/2026-03-26-pulser-eval-design.md
+++ b/docs/superpowers/specs/2026-03-26-pulser-eval-design.md
@@ -64,6 +64,8 @@ tests:
 |-----------|------|
 | `contains: "text"` | 출력에 해당 문자열 포함 |
 | `not-contains: "text"` | 출력에 해당 문자열 미포함 |
+| `starts-with: "text"` | 출력이 해당 문자열로 시작 |
+| `ends-with: "text"` | 출력이 해당 문자열로 종료 |
 | `min-length: N` | 출력 길이 N 이상 |
 | `max-length: N` | 출력 길이 N 이하 |
 | `matches: "regex"` | 정규식 매칭 |

--- a/src/eval/assertions.ts
+++ b/src/eval/assertions.ts
@@ -15,6 +15,14 @@ export function runAssertions(output: string, assertions: AssertionDef[]): Asser
       if (output.includes(assertion["not-contains"])) {
         return { passed: false, failureReason: `expected not-contains "${assertion["not-contains"]}", found in output` };
       }
+    } else if ("starts-with" in assertion) {
+      if (!output.startsWith(assertion["starts-with"])) {
+        return { passed: false, failureReason: `expected starts-with "${assertion["starts-with"]}"` };
+      }
+    } else if ("ends-with" in assertion) {
+      if (!output.endsWith(assertion["ends-with"])) {
+        return { passed: false, failureReason: `expected ends-with "${assertion["ends-with"]}"` };
+      }
     } else if ("min-length" in assertion) {
       if (output.length < assertion["min-length"]) {
         return { passed: false, failureReason: `expected min-length ${assertion["min-length"]}, got ${output.length}` };

--- a/src/eval/types.ts
+++ b/src/eval/types.ts
@@ -11,6 +11,8 @@ export interface TestCase {
 export type AssertionDef =
   | { contains: string }
   | { "not-contains": string }
+  | { "starts-with": string }
+  | { "ends-with": string }
   | { "min-length": number }
   | { "max-length": number }
   | { matches: string };


### PR DESCRIPTION
## Summary
- add `starts-with` and `ends-with` eval assertion types
- document the new assertion keys in the English and Korean READMEs plus the eval design spec

## Validation
- `pnpm lint`
- `pnpm build`

Refs #2